### PR TITLE
fix bug in docker build and run  proccess

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Base image containing OpenJDK 8, maintained by RedHat
-FROM adoptopenjdk/openjdk8
+FROM adoptopenjdk:8-jre-hotspot
 
 # Set name of user
 ARG USER=user
 
 # Update apt repo and install sudo package
-RUN apt-get update && apt-get install -y sudo
+RUN apt-get update && \
+    apt-get install -y sudo && \
+    apt-get install -yq dmidecode && \
+    rm -rf /var/lib/apt/lists/*
 
 # Add the user with no password
 RUN adduser --disabled-password --gecos '' $USER
@@ -18,10 +21,12 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/$USER
 USER $USER
 
 # Symlink to java executable to make it available to sudo user
-RUN sudo ln -s $JAVA_HOME/bin/java/usr/bin/java
+RUN sudo ln -s $JAVA_HOME/bin/java /usr/bin/java
 
 # Copy jar from target to working directory
 COPY target/*.jar /ward.jar
+
+EXPOSE 4000
 
 # Run jar as sudo user on entry point
 ENTRYPOINT sudo java -jar ward.jar

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Ward works nice on all popular operating systems, because it uses [OSHI](https:/
 
     1. Clone the project
     2. mvn clean package
-    3. docker build --tag ward
-    4. docker run --rm -it --name ward -p 8082:80 ward
-    5. Go to localhost:8082 in web browser
+    3. docker build --tag ward .
+    4. docker run --rm -it --name ward -p 4000:4000 -p <application port>:<application port> --privileged ward
+    5. Go to localhost:4000 in web browser, input the same application port
     
     NOTE: Thanks to NangiDev


### PR DESCRIPTION
I think #26 and #27 are the same bug.

Add `--privileged` to the `docker run` command to use `dmidecode` in the docker container.